### PR TITLE
Init symbol lookup

### DIFF
--- a/docs/symbol_resolution.md
+++ b/docs/symbol_resolution.md
@@ -1,0 +1,213 @@
+# Symbol Resolution Feature
+
+This document describes the new symbol resolution feature that allows stock orders to include the trading symbol in addition to the instrument URL and ID.
+
+## Overview
+
+Previously, the Orders data client only returned Robinhood's internal instrument URL and instrument ID. Now, the client can optionally resolve these to actual trading symbols (e.g., "CRDO", "AAPL") by making additional API calls to fetch instrument details.
+
+## Features
+
+### Automatic Symbol Resolution
+
+By default, all stock orders now include the resolved trading symbol:
+
+```python
+from robinhood_client.data import OrdersDataClient, StockOrdersRequest
+from robinhood_client.common.session import FileSystemSessionStorage
+
+# Initialize client
+session_storage = FileSystemSessionStorage()
+client = OrdersDataClient(session_storage)
+
+# Get orders with automatic symbol resolution
+request = StockOrdersRequest(account_number="your_account")
+orders = client.get_stock_orders(request)
+
+for order in orders:
+    print(f"Order: {order.symbol} ({order.state})")  # e.g., "Order: CRDO (filled)"
+```
+
+### Configurable Resolution
+
+Symbol resolution can be disabled for better performance when symbols aren't needed:
+
+```python
+# Disable symbol resolution
+request = StockOrdersRequest(
+    account_number="your_account",
+    resolve_symbols=False
+)
+orders = client.get_stock_orders(request)
+
+for order in orders:
+    print(f"Instrument: {order.instrument}")  # Raw instrument URL
+    print(f"Symbol: {order.symbol}")  # Will be None
+```
+
+### Intelligent Caching
+
+The symbol resolution uses an intelligent caching system to minimize API calls:
+
+```python
+# Access the instrument cache directly
+instrument_client = client._instrument_client
+
+# Get cache statistics
+stats = instrument_client.get_cache_stats()
+print(f"Cached symbols: {stats['symbol_cache_size']}")
+
+# Clear cache if needed
+instrument_client.clear_cache()
+```
+
+## API Reference
+
+### StockOrder Schema Changes
+
+The `StockOrder` model now includes an optional `symbol` field:
+
+```python
+class StockOrder(RobinhoodBaseModel):
+    # ... existing fields ...
+    
+    symbol: Optional[str] = None
+    """The trading symbol for the stock (populated when symbol resolution is enabled)."""
+```
+
+### Request Model Changes
+
+Both `StockOrderRequest` and `StockOrdersRequest` now support a `resolve_symbols` parameter:
+
+```python
+class StockOrdersRequest(RobinhoodBaseModel):
+    account_number: str
+    start_date: Optional[date | str] = None
+    page_size: Optional[int] = 10
+    resolve_symbols: bool = True  # New parameter, defaults to True
+```
+
+### New InstrumentCacheClient
+
+A new client is available for advanced instrument data operations:
+
+```python
+from robinhood_client.data import InstrumentCacheClient
+
+client = InstrumentCacheClient(session_storage)
+
+# Get symbol by instrument ID
+symbol = client.get_symbol_by_instrument_id("e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6")
+
+# Get symbol by instrument URL
+symbol = client.get_symbol_by_instrument_url(
+    "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+)
+
+# Get full instrument data
+instrument = client.get_instrument_by_id("e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6")
+```
+
+## Performance Considerations
+
+### Caching Strategy
+
+- **Symbol Cache**: Stores instrument_id -> symbol mappings
+- **Instrument Cache**: Stores full instrument objects for potential future use
+- **Automatic Cleanup**: No automatic cleanup implemented; use `clear_cache()` if memory is a concern
+
+### API Call Optimization
+
+- Only unique instruments per page trigger new API calls
+- Subsequent requests for the same instruments use cached data
+- Pagination respects caching across different pages
+
+### When to Disable Resolution
+
+Consider disabling symbol resolution when:
+
+- Processing large numbers of orders where symbols aren't needed
+- Implementing high-frequency operations where latency matters
+- Working with orders programmatically where instrument IDs are sufficient
+
+## Backwards Compatibility
+
+This feature is fully backwards compatible:
+
+- Existing code continues to work without changes
+- Symbol resolution is enabled by default
+- The `symbol` field is optional and won't break existing deserialization
+- All existing fields and functionality remain unchanged
+
+## Options Orders
+
+Currently, symbol resolution is only implemented for stock orders. Options orders already include a `chain_symbol` field that provides the underlying symbol. Future releases may extend this functionality to options if needed.
+
+## Error Handling
+
+The symbol resolution is designed to be fault-tolerant:
+
+- Network errors during symbol lookup don't fail the main order request
+- Invalid or missing instrument data results in `None` symbol values
+- Cache errors are logged but don't interrupt normal operation
+- Failed symbol resolution doesn't prevent order data from being returned
+
+## Example Usage
+
+### Basic Usage
+
+```python
+from robinhood_client.data import OrdersDataClient, StockOrdersRequest
+from robinhood_client.common.session import FileSystemSessionStorage
+
+# Setup
+session_storage = FileSystemSessionStorage()
+client = OrdersDataClient(session_storage)
+
+# Get recent orders with symbols
+request = StockOrdersRequest(account_number="your_account_number")
+result = client.get_stock_orders(request)
+
+# Process orders
+for order in result:
+    if order.symbol:
+        print(f"{order.symbol}: {order.state} - {order.side} {order.quantity}")
+    else:
+        print(f"Unknown symbol: {order.state} - {order.side} {order.quantity}")
+```
+
+### Performance-Optimized Usage
+
+```python
+# For high-volume processing, disable symbol resolution
+request = StockOrdersRequest(
+    account_number="your_account_number", 
+    resolve_symbols=False,
+    page_size=100  # Larger page size for fewer API calls
+)
+
+result = client.get_stock_orders(request)
+
+# Process using instrument IDs instead of symbols
+for order in result:
+    print(f"Instrument ID: {order.instrument_id}, State: {order.state}")
+```
+
+### Manual Symbol Resolution
+
+```python
+# Get orders without automatic resolution
+request = StockOrdersRequest(
+    account_number="your_account_number",
+    resolve_symbols=False
+)
+result = client.get_stock_orders(request)
+
+# Manually resolve symbols for specific orders
+instrument_client = client._instrument_client
+
+for order in result:
+    if order.state == "filled":  # Only resolve for filled orders
+        symbol = instrument_client.get_symbol_by_instrument_url(order.instrument)
+        print(f"Filled order: {symbol}")
+```

--- a/examples/symbol_resolution_example.py
+++ b/examples/symbol_resolution_example.py
@@ -9,12 +9,12 @@ def main():
     # Initialize the client with session storage
     session_storage = FileSystemSessionStorage()
     orders_client = OrdersDataClient(session_storage)
-    
+
     # Example 1: Get orders with symbol resolution enabled (default)
     print("=== Example 1: Orders with symbol resolution (default) ===")
     request = StockOrdersRequest(account_number="your_account_number")
     orders_result = orders_client.get_stock_orders(request)
-    
+
     for order in orders_result:
         print(f"Order ID: {order.id}")
         print(f"Symbol: {order.symbol}")  # This will be populated
@@ -22,32 +22,33 @@ def main():
         print(f"Side: {order.side}")
         print(f"Quantity: {order.quantity}")
         print("---")
-    
+
     # Example 2: Get orders without symbol resolution
     print("=== Example 2: Orders without symbol resolution ===")
     request_no_symbols = StockOrdersRequest(
-        account_number="your_account_number",
-        resolve_symbols=False
+        account_number="your_account_number", resolve_symbols=False
     )
     orders_result_no_symbols = orders_client.get_stock_orders(request_no_symbols)
-    
+
     for order in orders_result_no_symbols:
         print(f"Order ID: {order.id}")
         print(f"Symbol: {order.symbol}")  # This will be None
         print(f"Instrument URL: {order.instrument}")  # Raw instrument URL
         print(f"State: {order.state}")
         print("---")
-    
+
     # Example 3: Manual symbol resolution using instrument client
     print("=== Example 3: Manual symbol resolution ===")
     # Access the underlying instrument client
     instrument_client = orders_client._instrument_client
-    
+
     # Resolve symbol from instrument URL
-    example_url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+    example_url = (
+        "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+    )
     symbol = instrument_client.get_symbol_by_instrument_url(example_url)
     print(f"Symbol for instrument URL: {symbol}")  # Should print "CRDO"
-    
+
     # Check cache stats
     cache_stats = instrument_client.get_cache_stats()
     print(f"Cache statistics: {cache_stats}")

--- a/examples/symbol_resolution_example.py
+++ b/examples/symbol_resolution_example.py
@@ -1,0 +1,57 @@
+"""Example demonstrating symbol resolution for stock orders."""
+
+from robinhood_client.data import OrdersDataClient, StockOrdersRequest
+from robinhood_client.common.session import FileSystemSessionStorage
+
+
+def main():
+    """Demonstrate symbol resolution functionality."""
+    # Initialize the client with session storage
+    session_storage = FileSystemSessionStorage()
+    orders_client = OrdersDataClient(session_storage)
+    
+    # Example 1: Get orders with symbol resolution enabled (default)
+    print("=== Example 1: Orders with symbol resolution (default) ===")
+    request = StockOrdersRequest(account_number="your_account_number")
+    orders_result = orders_client.get_stock_orders(request)
+    
+    for order in orders_result:
+        print(f"Order ID: {order.id}")
+        print(f"Symbol: {order.symbol}")  # This will be populated
+        print(f"State: {order.state}")
+        print(f"Side: {order.side}")
+        print(f"Quantity: {order.quantity}")
+        print("---")
+    
+    # Example 2: Get orders without symbol resolution
+    print("=== Example 2: Orders without symbol resolution ===")
+    request_no_symbols = StockOrdersRequest(
+        account_number="your_account_number",
+        resolve_symbols=False
+    )
+    orders_result_no_symbols = orders_client.get_stock_orders(request_no_symbols)
+    
+    for order in orders_result_no_symbols:
+        print(f"Order ID: {order.id}")
+        print(f"Symbol: {order.symbol}")  # This will be None
+        print(f"Instrument URL: {order.instrument}")  # Raw instrument URL
+        print(f"State: {order.state}")
+        print("---")
+    
+    # Example 3: Manual symbol resolution using instrument client
+    print("=== Example 3: Manual symbol resolution ===")
+    # Access the underlying instrument client
+    instrument_client = orders_client._instrument_client
+    
+    # Resolve symbol from instrument URL
+    example_url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+    symbol = instrument_client.get_symbol_by_instrument_url(example_url)
+    print(f"Symbol for instrument URL: {symbol}")  # Should print "CRDO"
+    
+    # Check cache stats
+    cache_stats = instrument_client.get_cache_stats()
+    print(f"Cache statistics: {cache_stats}")
+
+
+if __name__ == "__main__":
+    main()

--- a/robinhood_client/common/__init__.py
+++ b/robinhood_client/common/__init__.py
@@ -1,7 +1,7 @@
 """Common module exports."""
 
 from .cursor import Cursor, ApiCursor, PaginatedResult, CursorResponse
-from .schema import StockOrder, StockOrdersPageResponse
+from .schema import StockOrder, StockOrdersPageResponse, Instrument
 from .session import SessionStorage, FileSystemSessionStorage, AuthSession
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
     "CursorResponse",
     "StockOrder",
     "StockOrdersPageResponse",
+    "Instrument",
     "SessionStorage",
     "FileSystemSessionStorage",
     "AuthSession",

--- a/robinhood_client/common/schema.py
+++ b/robinhood_client/common/schema.py
@@ -19,6 +19,163 @@ class RobinhoodBaseModel(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
 
+class Instrument(RobinhoodBaseModel):
+    """Represents a financial instrument (stock) from the Robinhood API."""
+
+    id: str
+    """The unique identifier for the instrument."""
+
+    url: str
+    """The URL for the instrument details."""
+
+    quote: str
+    """The URL for the instrument's quote data."""
+
+    fundamentals: str
+    """The URL for the instrument's fundamentals data."""
+
+    splits: str
+    """The URL for the instrument's splits data."""
+
+    state: str
+    """The state of the instrument (e.g., 'active')."""
+
+    market: str
+    """The URL for the market where the instrument is traded."""
+
+    simple_name: str
+    """The simple name of the company."""
+
+    name: str
+    """The full legal name of the company."""
+
+    tradeable: bool
+    """Whether the instrument is tradeable."""
+
+    tradability: str
+    """The tradability status of the instrument."""
+
+    symbol: str
+    """The trading symbol for the instrument."""
+
+    bloomberg_unique: Optional[str] = None
+    """The Bloomberg unique identifier."""
+
+    margin_initial_ratio: str
+    """The initial margin ratio for the instrument."""
+
+    maintenance_ratio: str
+    """The maintenance margin ratio for the instrument."""
+
+    country: str
+    """The country where the instrument is domiciled."""
+
+    day_trade_ratio: str
+    """The day trading buying power ratio."""
+
+    list_date: Optional[str] = None
+    """The date when the instrument was listed."""
+
+    min_tick_size: Optional[str | float] = None
+    """The minimum tick size for the instrument."""
+
+    type: str
+    """The type of the instrument (e.g., 'stock')."""
+
+    tradable_chain_id: str
+    """The unique identifier for the tradable options chain."""
+
+    rhs_tradability: str
+    """The Robinhood Gold tradability status."""
+
+    affiliate_tradability: str
+    """The affiliate tradability status."""
+
+    fractional_tradability: str
+    """The fractional share tradability status."""
+
+    short_selling_tradability: str
+    """The short selling tradability status."""
+
+    default_collar_fraction: str
+    """The default collar fraction for orders."""
+
+    # IPO-related fields
+    ipo_access_status: Optional[str] = None
+    """The IPO access status."""
+
+    ipo_access_cob_deadline: Optional[str] = None
+    """The IPO access close of business deadline."""
+
+    ipo_s1_url: Optional[str] = None
+    """The URL for the IPO S-1 filing."""
+
+    ipo_roadshow_url: Optional[str] = None
+    """The URL for the IPO roadshow."""
+
+    is_spac: bool
+    """Whether the instrument is a SPAC."""
+
+    is_test: bool
+    """Whether this is a test instrument."""
+
+    ipo_access_supports_dsp: bool
+    """Whether IPO access supports direct stock purchase."""
+
+    # Extended hours and halt information
+    extended_hours_fractional_tradability: bool
+    """Whether fractional shares are tradeable in extended hours."""
+
+    internal_halt_reason: str
+    """The reason for any internal trading halt."""
+
+    internal_halt_details: str
+    """Additional details about any internal trading halt."""
+
+    internal_halt_sessions: Optional[str] = None
+    """The sessions affected by any internal trading halt."""
+
+    internal_halt_start_time: Optional[str] = None
+    """The start time of any internal trading halt."""
+
+    internal_halt_end_time: Optional[str] = None
+    """The end time of any internal trading halt."""
+
+    internal_halt_source: str
+    """The source of any internal trading halt."""
+
+    # Additional trading parameters
+    all_day_tradability: str
+    """The all-day tradability status."""
+
+    notional_estimated_quantity_decimals: int
+    """The number of decimal places for notional estimated quantities."""
+
+    tax_security_type: str
+    """The tax security type classification."""
+
+    reserved_buying_power_percent_queued: str
+    """The reserved buying power percentage for queued orders."""
+
+    reserved_buying_power_percent_immediate: str
+    """The reserved buying power percentage for immediate orders."""
+
+    otc_market_tier: str
+    """The OTC market tier classification."""
+
+    car_required: bool
+    """Whether CAR (Customer Account Representative) is required."""
+
+    high_risk_maintenance_ratio: str
+    """The maintenance ratio for high-risk positions."""
+
+    low_risk_maintenance_ratio: str
+    """The maintenance ratio for low-risk positions."""
+
+    default_preset_percent_limit: str
+    """The default preset percent limit for orders."""
+
+
 class Currency(RobinhoodBaseModel):
     """Represents a currency amount with its code and identifier."""
 
@@ -104,6 +261,9 @@ class StockOrder(RobinhoodBaseModel):
 
     instrument_id: str
     """The unique identifier for the instrument."""
+
+    symbol: Optional[str] = None
+    """The trading symbol for the stock (populated when symbol resolution is enabled)."""
 
     cumulative_quantity: str | float
     """The cumulative quantity filled."""

--- a/robinhood_client/data/__init__.py
+++ b/robinhood_client/data/__init__.py
@@ -2,6 +2,7 @@
 
 from .orders import OrdersDataClient
 from .options import OptionsDataClient
+from .instruments import InstrumentCacheClient
 from .requests import (
     StockOrdersRequest,
     StockOrderRequest,
@@ -11,7 +12,8 @@ from .requests import (
 
 __all__ = [
     "OrdersDataClient",
-    "OptionsDataClient",
+    "OptionsDataClient", 
+    "InstrumentCacheClient",
     "StockOrdersRequest",
     "StockOrderRequest",
     "OptionsOrdersRequest",

--- a/robinhood_client/data/__init__.py
+++ b/robinhood_client/data/__init__.py
@@ -12,7 +12,7 @@ from .requests import (
 
 __all__ = [
     "OrdersDataClient",
-    "OptionsDataClient", 
+    "OptionsDataClient",
     "InstrumentCacheClient",
     "StockOrdersRequest",
     "StockOrderRequest",

--- a/robinhood_client/data/instruments.py
+++ b/robinhood_client/data/instruments.py
@@ -1,0 +1,159 @@
+"""Client for fetching and caching instrument data."""
+
+import logging
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from robinhood_client.common.clients import BaseOAuthClient
+from robinhood_client.common.session import SessionStorage
+from robinhood_client.common.constants import BASE_API_URL
+from robinhood_client.common.schema import Instrument
+
+logger = logging.getLogger(__name__)
+
+
+class InstrumentCacheClient(BaseOAuthClient):
+    """Client for fetching and caching instrument data with symbol lookup functionality.
+    
+    This client provides caching capabilities to avoid repeated API calls for the same
+    instruments. It's designed to be used by other data clients to resolve symbols
+    from instrument URLs or IDs.
+    """
+
+    def __init__(self, session_storage: SessionStorage):
+        """Initialize the instrument cache client.
+        
+        Args:
+            session_storage: Session storage for authentication
+        """
+        super().__init__(url=BASE_API_URL, session_storage=session_storage)
+        self._symbol_cache: Dict[str, str] = {}  # instrument_id -> symbol
+        self._instrument_cache: Dict[str, Instrument] = {}  # instrument_id -> full instrument
+
+    def get_symbol_by_instrument_id(self, instrument_id: str) -> Optional[str]:
+        """Get the trading symbol for an instrument by its ID.
+        
+        This method first checks the cache, and if not found, fetches the instrument
+        from the API and caches both the symbol and full instrument data.
+        
+        Args:
+            instrument_id: The unique identifier for the instrument
+            
+        Returns:
+            The trading symbol (e.g., 'CRDO') or None if not found
+        """
+        # Check symbol cache first
+        if instrument_id in self._symbol_cache:
+            logger.debug(f"Symbol cache hit for instrument_id: {instrument_id}")
+            return self._symbol_cache[instrument_id]
+        
+        # Fetch and cache the instrument
+        instrument = self._fetch_and_cache_instrument(instrument_id)
+        return instrument.symbol if instrument else None
+
+    def get_symbol_by_instrument_url(self, instrument_url: str) -> Optional[str]:
+        """Get the trading symbol for an instrument by its URL.
+        
+        Extracts the instrument ID from the URL and uses get_symbol_by_instrument_id.
+        
+        Args:
+            instrument_url: The URL for the instrument (e.g., 'https://api.robinhood.com/instruments/abc123/')
+            
+        Returns:
+            The trading symbol (e.g., 'CRDO') or None if not found
+        """
+        instrument_id = self._extract_instrument_id_from_url(instrument_url)
+        if not instrument_id:
+            logger.warning(f"Could not extract instrument ID from URL: {instrument_url}")
+            return None
+        
+        return self.get_symbol_by_instrument_id(instrument_id)
+
+    def get_instrument_by_id(self, instrument_id: str) -> Optional[Instrument]:
+        """Get the full instrument data by its ID.
+        
+        This method first checks the cache, and if not found, fetches the instrument
+        from the API and caches it.
+        
+        Args:
+            instrument_id: The unique identifier for the instrument
+            
+        Returns:
+            The full Instrument object or None if not found
+        """
+        # Check instrument cache first
+        if instrument_id in self._instrument_cache:
+            logger.debug(f"Instrument cache hit for instrument_id: {instrument_id}")
+            return self._instrument_cache[instrument_id]
+        
+        # Fetch and cache the instrument
+        return self._fetch_and_cache_instrument(instrument_id)
+
+    def clear_cache(self) -> None:
+        """Clear both symbol and instrument caches."""
+        self._symbol_cache.clear()
+        self._instrument_cache.clear()
+        logger.info("Instrument cache cleared")
+
+    def get_cache_stats(self) -> Dict[str, int]:
+        """Get statistics about the cache.
+        
+        Returns:
+            Dictionary with cache statistics including sizes
+        """
+        return {
+            "symbol_cache_size": len(self._symbol_cache),
+            "instrument_cache_size": len(self._instrument_cache)
+        }
+
+    def _fetch_and_cache_instrument(self, instrument_id: str) -> Optional[Instrument]:
+        """Fetch instrument data from API and cache it.
+        
+        Args:
+            instrument_id: The unique identifier for the instrument
+            
+        Returns:
+            The Instrument object or None if not found/error occurred
+        """
+        try:
+            endpoint = f"/instruments/{instrument_id}/"
+            logger.debug(f"Fetching instrument data for ID: {instrument_id}")
+            
+            response = self.request_get(endpoint)
+            instrument = Instrument(**response)
+            
+            # Cache both the symbol and full instrument
+            self._symbol_cache[instrument_id] = instrument.symbol
+            self._instrument_cache[instrument_id] = instrument
+            
+            logger.debug(f"Cached instrument {instrument_id} with symbol: {instrument.symbol}")
+            return instrument
+            
+        except Exception as e:
+            logger.error(f"Failed to fetch instrument {instrument_id}: {e}")
+            return None
+
+    def _extract_instrument_id_from_url(self, instrument_url: str) -> Optional[str]:
+        """Extract instrument ID from a Robinhood instrument URL.
+        
+        Args:
+            instrument_url: The URL (e.g., 'https://api.robinhood.com/instruments/abc123/')
+            
+        Returns:
+            The instrument ID or None if extraction fails
+        """
+        try:
+            # Parse the URL and extract the path
+            parsed_url = urlparse(instrument_url)
+            path_parts = parsed_url.path.strip('/').split('/')
+            
+            # Expected format: /instruments/{instrument_id}/
+            if len(path_parts) >= 2 and path_parts[0] == 'instruments':
+                return path_parts[1]
+            
+            logger.warning(f"Unexpected URL format: {instrument_url}")
+            return None
+            
+        except Exception as e:
+            logger.error(f"Error extracting instrument ID from URL {instrument_url}: {e}")
+            return None

--- a/robinhood_client/data/instruments.py
+++ b/robinhood_client/data/instruments.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class InstrumentCacheClient(BaseOAuthClient):
     """Client for fetching and caching instrument data with symbol lookup functionality.
-    
+
     This client provides caching capabilities to avoid repeated API calls for the same
     instruments. It's designed to be used by other data clients to resolve symbols
     from instrument URLs or IDs.
@@ -22,23 +22,25 @@ class InstrumentCacheClient(BaseOAuthClient):
 
     def __init__(self, session_storage: SessionStorage):
         """Initialize the instrument cache client.
-        
+
         Args:
             session_storage: Session storage for authentication
         """
         super().__init__(url=BASE_API_URL, session_storage=session_storage)
         self._symbol_cache: Dict[str, str] = {}  # instrument_id -> symbol
-        self._instrument_cache: Dict[str, Instrument] = {}  # instrument_id -> full instrument
+        self._instrument_cache: Dict[
+            str, Instrument
+        ] = {}  # instrument_id -> full instrument
 
     def get_symbol_by_instrument_id(self, instrument_id: str) -> Optional[str]:
         """Get the trading symbol for an instrument by its ID.
-        
+
         This method first checks the cache, and if not found, fetches the instrument
         from the API and caches both the symbol and full instrument data.
-        
+
         Args:
             instrument_id: The unique identifier for the instrument
-            
+
         Returns:
             The trading symbol (e.g., 'CRDO') or None if not found
         """
@@ -46,38 +48,40 @@ class InstrumentCacheClient(BaseOAuthClient):
         if instrument_id in self._symbol_cache:
             logger.debug(f"Symbol cache hit for instrument_id: {instrument_id}")
             return self._symbol_cache[instrument_id]
-        
+
         # Fetch and cache the instrument
         instrument = self._fetch_and_cache_instrument(instrument_id)
         return instrument.symbol if instrument else None
 
     def get_symbol_by_instrument_url(self, instrument_url: str) -> Optional[str]:
         """Get the trading symbol for an instrument by its URL.
-        
+
         Extracts the instrument ID from the URL and uses get_symbol_by_instrument_id.
-        
+
         Args:
             instrument_url: The URL for the instrument (e.g., 'https://api.robinhood.com/instruments/abc123/')
-            
+
         Returns:
             The trading symbol (e.g., 'CRDO') or None if not found
         """
         instrument_id = self._extract_instrument_id_from_url(instrument_url)
         if not instrument_id:
-            logger.warning(f"Could not extract instrument ID from URL: {instrument_url}")
+            logger.warning(
+                f"Could not extract instrument ID from URL: {instrument_url}"
+            )
             return None
-        
+
         return self.get_symbol_by_instrument_id(instrument_id)
 
     def get_instrument_by_id(self, instrument_id: str) -> Optional[Instrument]:
         """Get the full instrument data by its ID.
-        
+
         This method first checks the cache, and if not found, fetches the instrument
         from the API and caches it.
-        
+
         Args:
             instrument_id: The unique identifier for the instrument
-            
+
         Returns:
             The full Instrument object or None if not found
         """
@@ -85,7 +89,7 @@ class InstrumentCacheClient(BaseOAuthClient):
         if instrument_id in self._instrument_cache:
             logger.debug(f"Instrument cache hit for instrument_id: {instrument_id}")
             return self._instrument_cache[instrument_id]
-        
+
         # Fetch and cache the instrument
         return self._fetch_and_cache_instrument(instrument_id)
 
@@ -97,63 +101,67 @@ class InstrumentCacheClient(BaseOAuthClient):
 
     def get_cache_stats(self) -> Dict[str, int]:
         """Get statistics about the cache.
-        
+
         Returns:
             Dictionary with cache statistics including sizes
         """
         return {
             "symbol_cache_size": len(self._symbol_cache),
-            "instrument_cache_size": len(self._instrument_cache)
+            "instrument_cache_size": len(self._instrument_cache),
         }
 
     def _fetch_and_cache_instrument(self, instrument_id: str) -> Optional[Instrument]:
         """Fetch instrument data from API and cache it.
-        
+
         Args:
             instrument_id: The unique identifier for the instrument
-            
+
         Returns:
             The Instrument object or None if not found/error occurred
         """
         try:
             endpoint = f"/instruments/{instrument_id}/"
             logger.debug(f"Fetching instrument data for ID: {instrument_id}")
-            
+
             response = self.request_get(endpoint)
             instrument = Instrument(**response)
-            
+
             # Cache both the symbol and full instrument
             self._symbol_cache[instrument_id] = instrument.symbol
             self._instrument_cache[instrument_id] = instrument
-            
-            logger.debug(f"Cached instrument {instrument_id} with symbol: {instrument.symbol}")
+
+            logger.debug(
+                f"Cached instrument {instrument_id} with symbol: {instrument.symbol}"
+            )
             return instrument
-            
+
         except Exception as e:
             logger.error(f"Failed to fetch instrument {instrument_id}: {e}")
             return None
 
     def _extract_instrument_id_from_url(self, instrument_url: str) -> Optional[str]:
         """Extract instrument ID from a Robinhood instrument URL.
-        
+
         Args:
             instrument_url: The URL (e.g., 'https://api.robinhood.com/instruments/abc123/')
-            
+
         Returns:
             The instrument ID or None if extraction fails
         """
         try:
             # Parse the URL and extract the path
             parsed_url = urlparse(instrument_url)
-            path_parts = parsed_url.path.strip('/').split('/')
-            
+            path_parts = parsed_url.path.strip("/").split("/")
+
             # Expected format: /instruments/{instrument_id}/
-            if len(path_parts) >= 2 and path_parts[0] == 'instruments':
+            if len(path_parts) >= 2 and path_parts[0] == "instruments":
                 return path_parts[1]
-            
+
             logger.warning(f"Unexpected URL format: {instrument_url}")
             return None
-            
+
         except Exception as e:
-            logger.error(f"Error extracting instrument ID from URL {instrument_url}: {e}")
+            logger.error(
+                f"Error extracting instrument ID from URL {instrument_url}: {e}"
+            )
             return None

--- a/robinhood_client/data/orders.py
+++ b/robinhood_client/data/orders.py
@@ -6,6 +6,7 @@ from robinhood_client.common.constants import BASE_API_URL
 from robinhood_client.common.schema import StockOrder, StockOrdersPageResponse
 from robinhood_client.common.cursor import ApiCursor, PaginatedResult
 
+from .instruments import InstrumentCacheClient
 from .requests import (
     StockOrderRequest,
     StockOrdersRequest,
@@ -17,6 +18,7 @@ class OrdersDataClient(BaseOAuthClient):
 
     def __init__(self, session_storage: SessionStorage):
         super().__init__(url=BASE_API_URL, session_storage=session_storage)
+        self._instrument_client = InstrumentCacheClient(session_storage)
 
     def get_stock_order(self, request: StockOrderRequest) -> StockOrder:
         """Gets information for a specific stock order.
@@ -26,9 +28,10 @@ class OrdersDataClient(BaseOAuthClient):
                 account_number: The Robinhood account number
                 order_id: The ID of the order to retrieve
                 start_date: Optional date to filter orders
+                resolve_symbols: Whether to resolve instrument symbols (default: True)
 
         Returns:
-            StockOrder with the order information
+            StockOrder with the order information (symbol populated if resolve_symbols=True)
         """
         params = {}
         endpoint = f"/orders/{request.order_id}/"
@@ -36,7 +39,15 @@ class OrdersDataClient(BaseOAuthClient):
             params["account_number"] = request.account_number
 
         res = self.request_get(endpoint, params=params)
-        return StockOrder(**res)
+        order = StockOrder(**res)
+        
+        # Resolve symbol if requested
+        if request.resolve_symbols:
+            symbol = self._instrument_client.get_symbol_by_instrument_url(order.instrument)
+            if symbol:
+                order.symbol = symbol
+
+        return order
 
     def get_stock_orders(
         self, request: StockOrdersRequest
@@ -51,6 +62,7 @@ class OrdersDataClient(BaseOAuthClient):
                 account_number: The Robinhood account number
                 start_date: Optional date filter for orders (accepts string or date object)
                 page_size: Optional pagination page size
+                resolve_symbols: Whether to resolve instrument symbols (default: True)
 
         Returns:
             PaginatedResult[StockOrder] that can be used for:
@@ -67,7 +79,7 @@ class OrdersDataClient(BaseOAuthClient):
             >>>
             >>> # Iterate through all pages
             >>> for order in result:
-            >>>     print(f"Order {order.id}: {order.state}")
+            >>>     print(f"Order {order.id}: {order.state} - {order.symbol}")
             >>>
             >>> # Manual pagination
             >>> cursor = result.cursor()
@@ -93,12 +105,55 @@ class OrdersDataClient(BaseOAuthClient):
             # Add default page_size only if not provided in request
             params["page_size"] = 10
 
-        # Create a cursor for this request
-        cursor = ApiCursor(
+        # Create a cursor for this request with symbol resolution
+        if request.resolve_symbols:
+            cursor = self._create_symbol_resolving_cursor(endpoint, params)
+        else:
+            cursor = ApiCursor(
+                client=self,
+                endpoint=endpoint,
+                response_model=StockOrdersPageResponse,
+                base_params=params,
+            )
+
+        return PaginatedResult(cursor)
+
+    def _create_symbol_resolving_cursor(self, endpoint: str, base_params: dict) -> ApiCursor[StockOrder]:
+        """Create a cursor that automatically resolves symbols for orders.
+        
+        Args:
+            endpoint: The API endpoint
+            base_params: Base parameters for the request
+            
+        Returns:
+            ApiCursor with symbol resolution
+        """
+        class SymbolResolvingApiCursor(ApiCursor[StockOrder]):
+            def __init__(self, orders_client, *args, **kwargs):
+                self._orders_client = orders_client
+                super().__init__(*args, **kwargs)
+            
+            def _fetch_current_page(self):
+                """Override to resolve symbols after fetching."""
+                super()._fetch_current_page()
+                if (self._current_page and self._current_page.results and 
+                    hasattr(self._orders_client, '_instrument_client')):
+                    # Resolve symbols for all orders in this page
+                    for order in self._current_page.results:
+                        if not order.symbol:  # Only resolve if not already set
+                            try:
+                                symbol = self._orders_client._instrument_client.get_symbol_by_instrument_url(order.instrument)
+                                if symbol:
+                                    order.symbol = symbol
+                            except Exception:
+                                # Silently handle any errors in symbol resolution
+                                # The order data is still valid without the symbol
+                                pass
+
+        return SymbolResolvingApiCursor(
+            self,
             client=self,
             endpoint=endpoint,
             response_model=StockOrdersPageResponse,
-            base_params=params,
+            base_params=base_params,
         )
-
-        return PaginatedResult(cursor)

--- a/robinhood_client/data/requests.py
+++ b/robinhood_client/data/requests.py
@@ -6,6 +6,7 @@ from robinhood_client.common.schema import RobinhoodBaseModel
 class StockOrderRequest(RobinhoodBaseModel):
     account_number: Optional[str] = None
     order_id: str
+    resolve_symbols: bool = True
 
 
 class StockOrderResponse(RobinhoodBaseModel):
@@ -18,6 +19,7 @@ class StockOrdersRequest(RobinhoodBaseModel):
     account_number: str
     start_date: Optional[date | str] = None
     page_size: Optional[int] = 10
+    resolve_symbols: bool = True
 
 
 class OptionsOrderRequest(RobinhoodBaseModel):

--- a/tests/unit/data/instrument_cache_tests.py
+++ b/tests/unit/data/instrument_cache_tests.py
@@ -21,7 +21,9 @@ class TestInstrumentCacheClient:
         assert instrument_id == "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
 
         # Test URL without trailing slash
-        url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+        url = (
+            "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+        )
         instrument_id = self.client._extract_instrument_id_from_url(url)
         assert instrument_id == "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
 
@@ -30,11 +32,11 @@ class TestInstrumentCacheClient:
         instrument_id = self.client._extract_instrument_id_from_url(invalid_url)
         assert instrument_id is None
 
-    @patch.object(InstrumentCacheClient, 'request_get')
+    @patch.object(InstrumentCacheClient, "request_get")
     def test_get_symbol_by_instrument_id_with_cache_miss(self, mock_request_get):
         """Test getting symbol when not in cache."""
         instrument_id = "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
-        
+
         # Mock API response
         mock_response = {
             "id": instrument_id,
@@ -86,16 +88,16 @@ class TestInstrumentCacheClient:
             "car_required": False,
             "high_risk_maintenance_ratio": "0.4000",
             "low_risk_maintenance_ratio": "0.2500",
-            "default_preset_percent_limit": "0.02"
+            "default_preset_percent_limit": "0.02",
         }
         mock_request_get.return_value = mock_response
 
         # Test getting symbol
         symbol = self.client.get_symbol_by_instrument_id(instrument_id)
-        
+
         assert symbol == "CRDO"
         mock_request_get.assert_called_once_with(f"/instruments/{instrument_id}/")
-        
+
         # Verify caching
         assert instrument_id in self.client._symbol_cache
         assert self.client._symbol_cache[instrument_id] == "CRDO"
@@ -104,25 +106,25 @@ class TestInstrumentCacheClient:
     def test_get_symbol_by_instrument_id_with_cache_hit(self):
         """Test getting symbol when already in cache."""
         instrument_id = "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
-        
+
         # Pre-populate cache
         self.client._symbol_cache[instrument_id] = "CRDO"
-        
+
         # Test getting symbol (should not make API call)
-        with patch.object(self.client, 'request_get') as mock_request_get:
+        with patch.object(self.client, "request_get") as mock_request_get:
             symbol = self.client.get_symbol_by_instrument_id(instrument_id)
-            
+
             assert symbol == "CRDO"
             mock_request_get.assert_not_called()
 
-    @patch.object(InstrumentCacheClient, 'get_symbol_by_instrument_id')
+    @patch.object(InstrumentCacheClient, "get_symbol_by_instrument_id")
     def test_get_symbol_by_instrument_url(self, mock_get_symbol):
         """Test getting symbol by URL."""
         url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
         mock_get_symbol.return_value = "CRDO"
-        
+
         symbol = self.client.get_symbol_by_instrument_url(url)
-        
+
         assert symbol == "CRDO"
         mock_get_symbol.assert_called_once_with("e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6")
 
@@ -131,12 +133,12 @@ class TestInstrumentCacheClient:
         # Pre-populate caches
         self.client._symbol_cache["test1"] = "SYM1"
         self.client._instrument_cache["test1"] = Mock()
-        
+
         # Test statistics
         stats = self.client.get_cache_stats()
         assert stats["symbol_cache_size"] == 1
         assert stats["instrument_cache_size"] == 1
-        
+
         # Test cache clearing
         self.client.clear_cache()
         stats = self.client.get_cache_stats()

--- a/tests/unit/data/instrument_cache_tests.py
+++ b/tests/unit/data/instrument_cache_tests.py
@@ -1,0 +1,144 @@
+"""Unit tests for the instrument cache functionality."""
+
+from unittest.mock import Mock, patch
+from robinhood_client.data.instruments import InstrumentCacheClient
+from robinhood_client.common.session import SessionStorage
+
+
+class TestInstrumentCacheClient:
+    """Test cases for InstrumentCacheClient."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_session_storage = Mock(spec=SessionStorage)
+        self.client = InstrumentCacheClient(self.mock_session_storage)
+
+    def test_extract_instrument_id_from_url(self):
+        """Test extracting instrument ID from URL."""
+        # Test valid URL
+        url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+        instrument_id = self.client._extract_instrument_id_from_url(url)
+        assert instrument_id == "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+
+        # Test URL without trailing slash
+        url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+        instrument_id = self.client._extract_instrument_id_from_url(url)
+        assert instrument_id == "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+
+        # Test invalid URL
+        invalid_url = "https://api.robinhood.com/invalid/path/"
+        instrument_id = self.client._extract_instrument_id_from_url(invalid_url)
+        assert instrument_id is None
+
+    @patch.object(InstrumentCacheClient, 'request_get')
+    def test_get_symbol_by_instrument_id_with_cache_miss(self, mock_request_get):
+        """Test getting symbol when not in cache."""
+        instrument_id = "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+        
+        # Mock API response
+        mock_response = {
+            "id": instrument_id,
+            "url": f"https://api.robinhood.com/instruments/{instrument_id}/",
+            "symbol": "CRDO",
+            "name": "Credo Technology Group Holding Ltd",
+            "simple_name": "Credo Technology Group",
+            "state": "active",
+            "market": "https://api.robinhood.com/markets/XNAS/",
+            "tradeable": True,
+            "tradability": "tradable",
+            "quote": "https://api.robinhood.com/quotes/CRDO/",
+            "fundamentals": "https://api.robinhood.com/fundamentals/CRDO/",
+            "splits": f"https://api.robinhood.com/instruments/{instrument_id}/splits/",
+            "bloomberg_unique": "EQ0000000083917793",
+            "margin_initial_ratio": "0.5000",
+            "maintenance_ratio": "0.4000",
+            "country": "US",
+            "day_trade_ratio": "0.2500",
+            "list_date": "2022-01-27",
+            "min_tick_size": None,
+            "type": "stock",
+            "tradable_chain_id": "1a09e53e-0858-4c40-9e07-fc14cca74ece",
+            "rhs_tradability": "tradable",
+            "affiliate_tradability": "tradable",
+            "fractional_tradability": "tradable",
+            "short_selling_tradability": "tradable",
+            "default_collar_fraction": "0.05",
+            "ipo_access_status": None,
+            "ipo_access_cob_deadline": None,
+            "ipo_s1_url": None,
+            "ipo_roadshow_url": None,
+            "is_spac": False,
+            "is_test": False,
+            "ipo_access_supports_dsp": False,
+            "extended_hours_fractional_tradability": False,
+            "internal_halt_reason": "",
+            "internal_halt_details": "",
+            "internal_halt_sessions": None,
+            "internal_halt_start_time": None,
+            "internal_halt_end_time": None,
+            "internal_halt_source": "",
+            "all_day_tradability": "tradable",
+            "notional_estimated_quantity_decimals": 5,
+            "tax_security_type": "stock",
+            "reserved_buying_power_percent_queued": "0.10000000",
+            "reserved_buying_power_percent_immediate": "0.05000000",
+            "otc_market_tier": "",
+            "car_required": False,
+            "high_risk_maintenance_ratio": "0.4000",
+            "low_risk_maintenance_ratio": "0.2500",
+            "default_preset_percent_limit": "0.02"
+        }
+        mock_request_get.return_value = mock_response
+
+        # Test getting symbol
+        symbol = self.client.get_symbol_by_instrument_id(instrument_id)
+        
+        assert symbol == "CRDO"
+        mock_request_get.assert_called_once_with(f"/instruments/{instrument_id}/")
+        
+        # Verify caching
+        assert instrument_id in self.client._symbol_cache
+        assert self.client._symbol_cache[instrument_id] == "CRDO"
+        assert instrument_id in self.client._instrument_cache
+
+    def test_get_symbol_by_instrument_id_with_cache_hit(self):
+        """Test getting symbol when already in cache."""
+        instrument_id = "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6"
+        
+        # Pre-populate cache
+        self.client._symbol_cache[instrument_id] = "CRDO"
+        
+        # Test getting symbol (should not make API call)
+        with patch.object(self.client, 'request_get') as mock_request_get:
+            symbol = self.client.get_symbol_by_instrument_id(instrument_id)
+            
+            assert symbol == "CRDO"
+            mock_request_get.assert_not_called()
+
+    @patch.object(InstrumentCacheClient, 'get_symbol_by_instrument_id')
+    def test_get_symbol_by_instrument_url(self, mock_get_symbol):
+        """Test getting symbol by URL."""
+        url = "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+        mock_get_symbol.return_value = "CRDO"
+        
+        symbol = self.client.get_symbol_by_instrument_url(url)
+        
+        assert symbol == "CRDO"
+        mock_get_symbol.assert_called_once_with("e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6")
+
+    def test_cache_management(self):
+        """Test cache clearing and statistics."""
+        # Pre-populate caches
+        self.client._symbol_cache["test1"] = "SYM1"
+        self.client._instrument_cache["test1"] = Mock()
+        
+        # Test statistics
+        stats = self.client.get_cache_stats()
+        assert stats["symbol_cache_size"] == 1
+        assert stats["instrument_cache_size"] == 1
+        
+        # Test cache clearing
+        self.client.clear_cache()
+        stats = self.client.get_cache_stats()
+        assert stats["symbol_cache_size"] == 0
+        assert stats["instrument_cache_size"] == 0

--- a/tests/unit/data/orders_symbol_tests.py
+++ b/tests/unit/data/orders_symbol_tests.py
@@ -1,0 +1,232 @@
+"""Unit tests for symbol resolution in orders client."""
+
+from unittest.mock import Mock, patch
+from robinhood_client.data.orders import OrdersDataClient
+from robinhood_client.data.requests import StockOrderRequest, StockOrdersRequest
+from robinhood_client.common.session import SessionStorage
+
+
+class TestOrdersDataClientSymbolResolution:
+    """Test cases for symbol resolution in OrdersDataClient."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_session_storage = Mock(spec=SessionStorage)
+        self.client = OrdersDataClient(self.mock_session_storage)
+
+    def test_get_stock_order_with_symbol_resolution_enabled(self):
+        """Test getting a single stock order with symbol resolution enabled."""
+        order_id = "test-order-id"
+        account_number = "test-account"
+        
+        # Mock the API response
+        mock_order_response = {
+            "id": order_id,
+            "ref_id": "ref123",
+            "url": f"https://api.robinhood.com/orders/{order_id}/",
+            "account": f"https://api.robinhood.com/accounts/{account_number}/",
+            "user_uuid": "user-uuid",
+            "position": "https://api.robinhood.com/positions/pos123/",
+            "cancel": None,
+            "instrument": "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/",
+            "instrument_id": "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6",
+            "cumulative_quantity": "0.00000000",
+            "average_price": None,
+            "fees": "0.00",
+            "sec_fees": "0.00",
+            "taf_fees": "0.00",
+            "cat_fees": "0.00",
+            "sales_taxes": [],
+            "state": "cancelled",
+            "derived_state": "cancelled",
+            "pending_cancel_open_agent": None,
+            "type": "market",
+            "side": "buy",
+            "time_in_force": "gfd",
+            "trigger": "immediate",
+            "price": None,
+            "stop_price": None,
+            "quantity": "1.00000000",
+            "reject_reason": None,
+            "created_at": "2023-01-01T00:00:00.000000Z",
+            "updated_at": "2023-01-01T00:05:00.000000Z",
+            "last_transaction_at": "2023-01-01T00:05:00.000000Z",
+            "executions": [],
+            "extended_hours": False,
+            "market_hours": "regular_hours",
+            "override_dtbp_checks": False,
+            "override_day_trade_checks": False,
+            "response_category": None,
+            "stop_triggered_at": None,
+            "last_trail_price": None,
+            "last_trail_price_updated_at": None,
+            "last_trail_price_source": None,
+            "dollar_based_amount": None,
+            "total_notional": None,
+            "executed_notional": None,
+            "investment_schedule_id": None,
+            "is_ipo_access_order": False,
+            "ipo_access_cancellation_reason": None,
+            "ipo_access_lower_collared_price": None,
+            "ipo_access_upper_collared_price": None,
+            "ipo_access_upper_price": None,
+            "ipo_access_lower_price": None,
+            "is_ipo_access_price_finalized": False,
+            "is_visible_to_user": True,
+            "has_ipo_access_custom_price_limit": False,
+            "is_primary_account": True,
+            "order_form_version": 6,
+            "preset_percent_limit": None,
+            "order_form_type": "share_based_market_buys",
+            "last_update_version": 2,
+            "placed_agent": "user",
+            "is_editable": False,
+            "replaces": None,
+            "user_cancel_request_state": "order_finalized",
+            "tax_lot_selection_type": None,
+            "position_effect": None
+        }
+
+        with patch.object(self.client, 'request_get') as mock_request_get, \
+             patch.object(self.client._instrument_client, 'get_symbol_by_instrument_url') as mock_get_symbol:
+            
+            mock_request_get.return_value = mock_order_response
+            mock_get_symbol.return_value = "CRDO"
+            
+            # Create request with symbol resolution enabled
+            request = StockOrderRequest(
+                account_number=account_number,
+                order_id=order_id,
+                resolve_symbols=True
+            )
+            
+            # Get the order
+            order = self.client.get_stock_order(request)
+            
+            # Verify API call
+            mock_request_get.assert_called_once_with(
+                f"/orders/{order_id}/", 
+                params={"account_number": account_number}
+            )
+            
+            # Verify symbol resolution was called
+            mock_get_symbol.assert_called_once_with(
+                "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+            )
+            
+            # Verify order properties
+            assert order.id == order_id
+            assert order.symbol == "CRDO"  # Symbol should be resolved
+            assert order.instrument == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+
+    def test_get_stock_order_with_symbol_resolution_disabled(self):
+        """Test getting a single stock order with symbol resolution disabled."""
+        order_id = "test-order-id"
+        account_number = "test-account"
+        
+        # Mock the API response (same as above)
+        mock_order_response = {
+            "id": order_id,
+            "ref_id": "ref123",
+            "url": f"https://api.robinhood.com/orders/{order_id}/",
+            "account": f"https://api.robinhood.com/accounts/{account_number}/",
+            "user_uuid": "user-uuid",
+            "position": "https://api.robinhood.com/positions/pos123/",
+            "cancel": None,
+            "instrument": "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/",
+            "instrument_id": "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6",
+            "cumulative_quantity": "0.00000000",
+            "average_price": None,
+            "fees": "0.00",
+            "sec_fees": "0.00",
+            "taf_fees": "0.00",
+            "cat_fees": "0.00",
+            "sales_taxes": [],
+            "state": "cancelled",
+            "derived_state": "cancelled",
+            "pending_cancel_open_agent": None,
+            "type": "market",
+            "side": "buy",
+            "time_in_force": "gfd",
+            "trigger": "immediate",
+            "price": None,
+            "stop_price": None,
+            "quantity": "1.00000000",
+            "reject_reason": None,
+            "created_at": "2023-01-01T00:00:00.000000Z",
+            "updated_at": "2023-01-01T00:05:00.000000Z",
+            "last_transaction_at": "2023-01-01T00:05:00.000000Z",
+            "executions": [],
+            "extended_hours": False,
+            "market_hours": "regular_hours",
+            "override_dtbp_checks": False,
+            "override_day_trade_checks": False,
+            "response_category": None,
+            "stop_triggered_at": None,
+            "last_trail_price": None,
+            "last_trail_price_updated_at": None,
+            "last_trail_price_source": None,
+            "dollar_based_amount": None,
+            "total_notional": None,
+            "executed_notional": None,
+            "investment_schedule_id": None,
+            "is_ipo_access_order": False,
+            "ipo_access_cancellation_reason": None,
+            "ipo_access_lower_collared_price": None,
+            "ipo_access_upper_collared_price": None,
+            "ipo_access_upper_price": None,
+            "ipo_access_lower_price": None,
+            "is_ipo_access_price_finalized": False,
+            "is_visible_to_user": True,
+            "has_ipo_access_custom_price_limit": False,
+            "is_primary_account": True,
+            "order_form_version": 6,
+            "preset_percent_limit": None,
+            "order_form_type": "share_based_market_buys",
+            "last_update_version": 2,
+            "placed_agent": "user",
+            "is_editable": False,
+            "replaces": None,
+            "user_cancel_request_state": "order_finalized",
+            "tax_lot_selection_type": None,
+            "position_effect": None
+        }
+
+        with patch.object(self.client, 'request_get') as mock_request_get, \
+             patch.object(self.client._instrument_client, 'get_symbol_by_instrument_url') as mock_get_symbol:
+            
+            mock_request_get.return_value = mock_order_response
+            
+            # Create request with symbol resolution disabled
+            request = StockOrderRequest(
+                account_number=account_number,
+                order_id=order_id,
+                resolve_symbols=False
+            )
+            
+            # Get the order
+            order = self.client.get_stock_order(request)
+            
+            # Verify API call
+            mock_request_get.assert_called_once_with(
+                f"/orders/{order_id}/", 
+                params={"account_number": account_number}
+            )
+            
+            # Verify symbol resolution was NOT called
+            mock_get_symbol.assert_not_called()
+            
+            # Verify order properties
+            assert order.id == order_id
+            assert order.symbol is None  # Symbol should not be resolved
+            assert order.instrument == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+
+    def test_request_defaults(self):
+        """Test that resolve_symbols defaults to True in request models."""
+        # Test StockOrderRequest
+        request = StockOrderRequest(order_id="test-id")
+        assert request.resolve_symbols is True
+        
+        # Test StockOrdersRequest
+        request = StockOrdersRequest(account_number="test-account")
+        assert request.resolve_symbols is True

--- a/tests/unit/data/orders_symbol_tests.py
+++ b/tests/unit/data/orders_symbol_tests.py
@@ -14,13 +14,11 @@ class TestOrdersDataClientSymbolResolution:
         self.mock_session_storage = Mock(spec=SessionStorage)
         self.client = OrdersDataClient(self.mock_session_storage)
 
-    def test_get_stock_order_with_symbol_resolution_enabled(self):
-        """Test getting a single stock order with symbol resolution enabled."""
-        order_id = "test-order-id"
-        account_number = "test-account"
-
-        # Mock the API response
-        mock_order_response = {
+    def create_mock_order_response(
+        self, order_id: str = "test-order-id", account_number: str = "test-account"
+    ) -> dict:
+        """Create a mock stock order response."""
+        return {
             "id": order_id,
             "ref_id": "ref123",
             "url": f"https://api.robinhood.com/orders/{order_id}/",
@@ -86,6 +84,13 @@ class TestOrdersDataClientSymbolResolution:
             "tax_lot_selection_type": None,
             "position_effect": None,
         }
+
+    def test_get_stock_order_with_symbol_resolution_enabled(self):
+        """Test getting a single stock order with symbol resolution enabled."""
+        order_id = "test-order-id"
+        account_number = "test-account"
+
+        mock_order_response = self.create_mock_order_response(order_id, account_number)
 
         with (
             patch.object(self.client, "request_get") as mock_request_get,
@@ -127,73 +132,7 @@ class TestOrdersDataClientSymbolResolution:
         order_id = "test-order-id"
         account_number = "test-account"
 
-        # Mock the API response (same as above)
-        mock_order_response = {
-            "id": order_id,
-            "ref_id": "ref123",
-            "url": f"https://api.robinhood.com/orders/{order_id}/",
-            "account": f"https://api.robinhood.com/accounts/{account_number}/",
-            "user_uuid": "user-uuid",
-            "position": "https://api.robinhood.com/positions/pos123/",
-            "cancel": None,
-            "instrument": "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/",
-            "instrument_id": "e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6",
-            "cumulative_quantity": "0.00000000",
-            "average_price": None,
-            "fees": "0.00",
-            "sec_fees": "0.00",
-            "taf_fees": "0.00",
-            "cat_fees": "0.00",
-            "sales_taxes": [],
-            "state": "cancelled",
-            "derived_state": "cancelled",
-            "pending_cancel_open_agent": None,
-            "type": "market",
-            "side": "buy",
-            "time_in_force": "gfd",
-            "trigger": "immediate",
-            "price": None,
-            "stop_price": None,
-            "quantity": "1.00000000",
-            "reject_reason": None,
-            "created_at": "2023-01-01T00:00:00.000000Z",
-            "updated_at": "2023-01-01T00:05:00.000000Z",
-            "last_transaction_at": "2023-01-01T00:05:00.000000Z",
-            "executions": [],
-            "extended_hours": False,
-            "market_hours": "regular_hours",
-            "override_dtbp_checks": False,
-            "override_day_trade_checks": False,
-            "response_category": None,
-            "stop_triggered_at": None,
-            "last_trail_price": None,
-            "last_trail_price_updated_at": None,
-            "last_trail_price_source": None,
-            "dollar_based_amount": None,
-            "total_notional": None,
-            "executed_notional": None,
-            "investment_schedule_id": None,
-            "is_ipo_access_order": False,
-            "ipo_access_cancellation_reason": None,
-            "ipo_access_lower_collared_price": None,
-            "ipo_access_upper_collared_price": None,
-            "ipo_access_upper_price": None,
-            "ipo_access_lower_price": None,
-            "is_ipo_access_price_finalized": False,
-            "is_visible_to_user": True,
-            "has_ipo_access_custom_price_limit": False,
-            "is_primary_account": True,
-            "order_form_version": 6,
-            "preset_percent_limit": None,
-            "order_form_type": "share_based_market_buys",
-            "last_update_version": 2,
-            "placed_agent": "user",
-            "is_editable": False,
-            "replaces": None,
-            "user_cancel_request_state": "order_finalized",
-            "tax_lot_selection_type": None,
-            "position_effect": None,
-        }
+        mock_order_response = self.create_mock_order_response(order_id, account_number)
 
         with (
             patch.object(self.client, "request_get") as mock_request_get,

--- a/tests/unit/data/orders_symbol_tests.py
+++ b/tests/unit/data/orders_symbol_tests.py
@@ -18,7 +18,7 @@ class TestOrdersDataClientSymbolResolution:
         """Test getting a single stock order with symbol resolution enabled."""
         order_id = "test-order-id"
         account_number = "test-account"
-        
+
         # Mock the API response
         mock_order_response = {
             "id": order_id,
@@ -84,46 +84,49 @@ class TestOrdersDataClientSymbolResolution:
             "replaces": None,
             "user_cancel_request_state": "order_finalized",
             "tax_lot_selection_type": None,
-            "position_effect": None
+            "position_effect": None,
         }
 
-        with patch.object(self.client, 'request_get') as mock_request_get, \
-             patch.object(self.client._instrument_client, 'get_symbol_by_instrument_url') as mock_get_symbol:
-            
+        with (
+            patch.object(self.client, "request_get") as mock_request_get,
+            patch.object(
+                self.client._instrument_client, "get_symbol_by_instrument_url"
+            ) as mock_get_symbol,
+        ):
             mock_request_get.return_value = mock_order_response
             mock_get_symbol.return_value = "CRDO"
-            
+
             # Create request with symbol resolution enabled
             request = StockOrderRequest(
-                account_number=account_number,
-                order_id=order_id,
-                resolve_symbols=True
+                account_number=account_number, order_id=order_id, resolve_symbols=True
             )
-            
+
             # Get the order
             order = self.client.get_stock_order(request)
-            
+
             # Verify API call
             mock_request_get.assert_called_once_with(
-                f"/orders/{order_id}/", 
-                params={"account_number": account_number}
+                f"/orders/{order_id}/", params={"account_number": account_number}
             )
-            
+
             # Verify symbol resolution was called
             mock_get_symbol.assert_called_once_with(
                 "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
             )
-            
+
             # Verify order properties
             assert order.id == order_id
             assert order.symbol == "CRDO"  # Symbol should be resolved
-            assert order.instrument == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+            assert (
+                order.instrument
+                == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+            )
 
     def test_get_stock_order_with_symbol_resolution_disabled(self):
         """Test getting a single stock order with symbol resolution disabled."""
         order_id = "test-order-id"
         account_number = "test-account"
-        
+
         # Mock the API response (same as above)
         mock_order_response = {
             "id": order_id,
@@ -189,44 +192,47 @@ class TestOrdersDataClientSymbolResolution:
             "replaces": None,
             "user_cancel_request_state": "order_finalized",
             "tax_lot_selection_type": None,
-            "position_effect": None
+            "position_effect": None,
         }
 
-        with patch.object(self.client, 'request_get') as mock_request_get, \
-             patch.object(self.client._instrument_client, 'get_symbol_by_instrument_url') as mock_get_symbol:
-            
+        with (
+            patch.object(self.client, "request_get") as mock_request_get,
+            patch.object(
+                self.client._instrument_client, "get_symbol_by_instrument_url"
+            ) as mock_get_symbol,
+        ):
             mock_request_get.return_value = mock_order_response
-            
+
             # Create request with symbol resolution disabled
             request = StockOrderRequest(
-                account_number=account_number,
-                order_id=order_id,
-                resolve_symbols=False
+                account_number=account_number, order_id=order_id, resolve_symbols=False
             )
-            
+
             # Get the order
             order = self.client.get_stock_order(request)
-            
+
             # Verify API call
             mock_request_get.assert_called_once_with(
-                f"/orders/{order_id}/", 
-                params={"account_number": account_number}
+                f"/orders/{order_id}/", params={"account_number": account_number}
             )
-            
+
             # Verify symbol resolution was NOT called
             mock_get_symbol.assert_not_called()
-            
+
             # Verify order properties
             assert order.id == order_id
             assert order.symbol is None  # Symbol should not be resolved
-            assert order.instrument == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+            assert (
+                order.instrument
+                == "https://api.robinhood.com/instruments/e84dc27d-7b8e-4f21-b3bd-5b02a5c99bc6/"
+            )
 
     def test_request_defaults(self):
         """Test that resolve_symbols defaults to True in request models."""
         # Test StockOrderRequest
         request = StockOrderRequest(order_id="test-id")
         assert request.resolve_symbols is True
-        
+
         # Test StockOrdersRequest
         request = StockOrdersRequest(account_number="test-account")
         assert request.resolve_symbols is True


### PR DESCRIPTION
Previously, the Orders data client only returned Robinhood's internal instrument URL and instrument ID. Now, the client can optionally resolve these to actual trading symbols (e.g., "CRDO", "AAPL") by making additional API calls to fetch instrument details.